### PR TITLE
anyprevout and anyprevoutanyscript unit tests

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -241,6 +241,9 @@ static constexpr size_t TAPROOT_CONTROL_MAX_SIZE = TAPROOT_CONTROL_BASE_SIZE + T
 template <class T>
 uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);
 
+template<typename T>
+bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const KeyVersion keyversion, const PrecomputedTransactionData& cache);
+
 class BaseSignatureChecker
 {
 public:

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -114,6 +114,24 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
+void static MutateInputs(CMutableTransaction &tx, const bool inPrevout, const bool inInputSequence) {
+
+    // mutate previous input
+    for (std::size_t in = 0; in < tx.vin.size(); in++) {
+        CTxIn &txin = tx.vin[in];
+
+        if (inPrevout) {
+            txin.prevout.hash = InsecureRand256();
+            txin.prevout.n = InsecureRandBits(2);
+        }
+
+        // mutate input sequences
+        if (inInputSequence) {
+            txin.nSequence = InsecureRand32();
+        }
+    }
+}
+
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
@@ -205,4 +223,161 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
     }
 }
+
+// Goal: check that SignatureHashOld and SignatureHash ignore sighash flags SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+BOOST_AUTO_TEST_CASE(sighash_anyprevout_legacy)
+{
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "[\n";
+    std::cout << "\t[\"raw_transaction, script, input_index, hashType, signature_hash (result)\"],\n";
+    int nRandomTests = 500;
+    #else
+    int nRandomTests = 50000;
+    #endif
+
+    for (int i=0; i<nRandomTests; i++) {
+
+        // random sighashs, with and without ANYPREVOUT*
+        int nHashType = InsecureRand32() & ~SIGHASH_INPUT_MASK;
+        int nHashTypeApo = nHashType | SIGHASH_ANYPREVOUT;
+        int nHashTypeApoas = nHashType | SIGHASH_ANYPREVOUTANYSCRIPT;
+
+        CMutableTransaction tx;
+        RandomTransaction(tx, (nHashType & SIGHASH_OUTPUT_MASK) == SIGHASH_SINGLE);
+        CScript scriptCode, mut_scriptCode;
+        RandomScript(scriptCode);
+        RandomScript(mut_scriptCode);
+
+        // remove code separators from old scripts because they are not serialized
+        CScript old_scriptCode(scriptCode), old_mut_scriptCode(mut_scriptCode);
+        FindAndDelete(old_scriptCode, CScript(OP_CODESEPARATOR));
+        FindAndDelete(old_mut_scriptCode, CScript(OP_CODESEPARATOR));
+        
+        int nIn = InsecureRandRange(tx.vin.size());
+
+        CMutableTransaction tx_mut_prevout(tx);      
+        MutateInputs(tx_mut_prevout, true, false); 
+
+        CMutableTransaction tx_mut_sequence(tx);      
+        MutateInputs(tx_mut_sequence, false, true); 
+
+        // test OLD signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 sho = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashType);
+        uint256 sho_apo = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashTypeApo);
+        uint256 sho_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashTypeApoas);
+
+        // mutate the previous output transaction
+        uint256 sho_mut_prevout = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashType);
+        uint256 sho_mut_prevout_apo = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashTypeApo);
+        uint256 sho_mut_prevout_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashTypeApoas);
+
+        // mutate the previous input script
+        uint256 sho_mut_script = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashType);
+        uint256 sho_mut_script_apo = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashTypeApo);
+        uint256 sho_mut_script_apoas = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashTypeApoas);
+
+        // mutate the input sequence
+        uint256 sho_mut_sequence = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashType);
+        uint256 sho_mut_sequence_apo = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashTypeApo);
+        uint256 sho_mut_sequence_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashTypeApoas);
+
+        // test BASE signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 shb = SignatureHash(old_scriptCode, tx, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_apo = SignatureHash(old_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_apoas = SignatureHash(old_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+        
+        // mutate the previous output transaction
+        uint256 shb_mut_prevout = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_prevout_apo = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_prevout_apoas = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // mutate the previous input script
+        uint256 shb_mut_script = SignatureHash(old_mut_scriptCode, tx, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_script_apo = SignatureHash(old_mut_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_script_apoas = SignatureHash(old_mut_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // mutate the input sequence
+        uint256 shb_mut_sequence = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_sequence_apo = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_sequence_apoas = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // test v0 signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 shv0 = SignatureHash(scriptCode, tx, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_apo = SignatureHash(scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_apoas = SignatureHash(scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the previous output transaction
+        uint256 shv0_mut_prevout = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_prevout_apo = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_prevout_apoas = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the previous input script
+        uint256 shv0_mut_script = SignatureHash(mut_scriptCode, tx, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_script_apo = SignatureHash(mut_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_script_apoas = SignatureHash(mut_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the input sequence
+        uint256 shv0_mut_sequence = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shv0_mut_sequence_apo = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shv0_mut_sequence_apoas = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        #if defined(PRINT_SIGHASH_JSON)
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << tx;
+
+        std::cout << "\t[\"" ;
+        std::cout << HexStr(ss.begin(), ss.end()) << "\", \"";
+        std::cout << HexStr(scriptCode) << "\", ";
+        std::cout << nIn << ", ";
+        std::cout << nHashType << ", \"";
+        std::cout << sho.GetHex() << "\"]";
+        if (i+1 != nRandomTests) {
+          std::cout << ",";
+        }
+        std::cout << "\n";
+        #endif
+
+        // check that legacy, base and v0/SEGWIT transactions ignore SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+
+        // check maleated previous input transaction creates different digests
+        BOOST_CHECK(sho != sho_mut_prevout);
+        BOOST_CHECK(sho_apo != sho_mut_prevout_apo);
+        BOOST_CHECK(sho_apoas != sho_mut_prevout_apoas);
+        BOOST_CHECK(shb != shb_mut_prevout);
+        BOOST_CHECK(shb_apo != shb_mut_prevout_apo);
+        BOOST_CHECK(shb_apoas != shb_mut_prevout_apoas);
+        BOOST_CHECK(shv0 != shv0_mut_prevout);
+        BOOST_CHECK(shv0_apo != shv0_mut_prevout_apo);
+        BOOST_CHECK(shv0_apoas != shv0_mut_prevout_apoas);
+
+        // check maleated input script creates different digests
+        if (old_scriptCode != old_mut_scriptCode) {
+            BOOST_CHECK(sho != sho_mut_script);
+            BOOST_CHECK(sho_apo != sho_mut_script_apo);
+            BOOST_CHECK(sho_apoas != sho_mut_script_apoas);
+            BOOST_CHECK(shb != shb_mut_script);
+            BOOST_CHECK(shb_apo != shb_mut_script_apo);
+            BOOST_CHECK(shb_apoas != shb_mut_script_apoas);
+            BOOST_CHECK(shv0 != shv0_mut_script);
+            BOOST_CHECK(shv0_apo != shv0_mut_script_apo);
+            BOOST_CHECK(shv0_apoas != shv0_mut_script_apoas);
+        }
+
+        // check maleated sequence creates different digests
+        BOOST_CHECK(sho != sho_mut_sequence);
+        BOOST_CHECK(sho_apo != sho_mut_sequence_apo);
+        BOOST_CHECK(sho_apoas != sho_mut_sequence_apoas);
+        BOOST_CHECK(shb != shb_mut_sequence);
+        BOOST_CHECK(shb_apo != shb_mut_sequence_apo);
+        BOOST_CHECK(shb_apoas != shb_mut_sequence_apoas);
+        BOOST_CHECK(shv0 != shv0_mut_sequence);
+        BOOST_CHECK(shv0_apo != shv0_mut_sequence_apo);
+        BOOST_CHECK(shv0_apoas != shv0_mut_sequence_apoas);
+    }
+
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "]\n";
+    #endif
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -132,6 +132,26 @@ void static MutateInputs(CMutableTransaction &tx, const bool inPrevout, const bo
     }
 }
 
+static std::vector<CTxOut> MutateSpentOutputs(const size_t inNumOutputs, const bool inInputScripts, const bool inValue) {
+    FastRandomContext context(InsecureRand256());
+
+    // default to nValue of 0 and witness script with address of all zeros
+    std::vector<CTxOut> spent_outputs(inNumOutputs, CTxOut(0, CScript() << OP_1 << std::vector<unsigned char>(WITNESS_V1_TAPROOT_SIZE, 0)));
+
+    for (std::size_t in = 0; in < spent_outputs.size(); in++) {
+
+        if (inInputScripts) {
+            spent_outputs[in].scriptPubKey = CScript() << OP_1 << context.randbytes(WITNESS_V1_TAPROOT_SIZE);
+        }
+        
+        if (inValue) {
+            // random, but not default nValue of 0  
+            spent_outputs[in].nValue = InsecureRandRange(99999999)+1;
+        }
+    }
+    return spent_outputs;
+}
+
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
@@ -375,6 +395,194 @@ BOOST_AUTO_TEST_CASE(sighash_anyprevout_legacy)
         BOOST_CHECK(shv0_apoas != shv0_mut_sequence_apoas);
     }
 
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "]\n";
+    #endif
+}
+
+// Goal: check that SignatureHashSchnorr generates the proper hash when inputs are maleated with SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+BOOST_AUTO_TEST_CASE(sighash_anyprevout_taproot)
+{
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "[\n";
+    std::cout << "\t[\"raw_transaction, script, input_index, hashType, signature_hash (result)\"],\n";
+    int nRandomTests = 500;
+    #else
+    int nRandomTests = 50000;
+    #endif
+
+    for (int i=0; i<nRandomTests; i++) {
+
+        // Test random sighash, excluding sighash input flags
+        int nHashType = InsecureRand32() & ~SIGHASH_INPUT_MASK;
+
+        CMutableTransaction tx;
+        RandomTransaction(tx, (nHashType & SIGHASH_OUTPUT_MASK) == SIGHASH_SINGLE);
+        std::for_each(tx.vin.begin(), tx.vin.end(), [](CTxIn& vin){ vin.scriptWitness.stack.push_back({OP_TRUE}); });
+        PrecomputedTransactionData txdata(tx);
+        txdata.Init(tx, MutateSpentOutputs(tx.vin.size(), false, false));
+
+        // test random transaction input
+        int nIn = InsecureRandRange(tx.vin.size());
+
+        // mutate the previous output transaction
+        CMutableTransaction tx_mut_prevout(tx);
+        MutateInputs(tx_mut_prevout, true, false);
+        PrecomputedTransactionData txdata_mut_prevout(tx_mut_prevout);
+        txdata_mut_prevout.Init(tx_mut_prevout, MutateSpentOutputs(tx_mut_prevout.vin.size(), false, false));
+
+        // mutate the previous input script
+        CMutableTransaction tx_mut_script(tx);
+        PrecomputedTransactionData txdata_mut_script(tx_mut_script);
+        txdata_mut_script.Init(tx_mut_script, MutateSpentOutputs(tx_mut_script.vin.size(), true, false));
+
+        // mutate the input sequence
+        CMutableTransaction tx_mut_sequence(tx);  
+        MutateInputs(tx_mut_sequence, false, true); 
+        PrecomputedTransactionData txdata_mut_sequence(tx_mut_sequence);
+        txdata_mut_sequence.Init(tx_mut_sequence, MutateSpentOutputs(tx_mut_sequence.vin.size(), false, false));
+
+        // mutate only the output values of the spent output
+        CMutableTransaction tx_mut_spent_value(tx);
+        PrecomputedTransactionData txdata_mut_spent_value(tx_mut_spent_value);
+        txdata_mut_spent_value.Init(tx_mut_spent_value, MutateSpentOutputs(tx_mut_spent_value.vin.size(), false, true));
+        
+        // only check signature version of v1/TAPSCRIPT (0x3) because EvalChecksig will not allow execution of v1/TAPROOT (0x2) transactions
+        SigVersion sigversion = SigVersion::TAPSCRIPT;
+
+        ScriptExecutionData execdata;
+        execdata.m_annex_init = true;
+        execdata.m_annex_present = InsecureRandBool();
+        execdata.m_annex_hash = InsecureRand256();
+        execdata.m_tapleaf_hash_init = true;
+        execdata.m_tapleaf_hash = InsecureRand256();
+        execdata.m_codeseparator_pos_init = true;
+        execdata.m_codeseparator_pos = InsecureRand32();
+        
+        int nHashType_outmask = nHashType & SIGHASH_OUTPUT_MASK;
+        int nHashType_inoutmask = nHashType & (SIGHASH_INPUT_MASK | SIGHASH_OUTPUT_MASK);
+
+        // any sighash that sets undefined input or output flags should fail
+        if (nHashType_inoutmask != nHashType_outmask && nHashType_inoutmask != nHashType) {
+            uint256 tmp;
+            BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType, sigversion, KeyVersion::TAPROOT, txdata));
+            BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType, sigversion, KeyVersion::ANYPREVOUT, txdata));
+        }
+
+        // check transactions using the TAPROOT key version reject ANYPREVOUT
+        {
+            // should fail all sighash input flags if no output flag is set
+            uint256 tmp;
+            if (nHashType_outmask == 0x0) {
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::TAPROOT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::TAPROOT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::TAPROOT, txdata));
+            }
+            // otherwise all other output sighash flags should fail when any input sighash flags are set except SIGHASH_ANYONECANPAY
+            else {
+                BOOST_CHECK(SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::TAPROOT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::TAPROOT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::TAPROOT, txdata));
+            }
+        }
+
+        // check transactions using the ANYPREVOUT key version
+        {
+            // compute base sighash without any input sighash flags
+            uint256 shts;
+            BOOST_CHECK(SignatureHashSchnorr(shts, execdata, tx, nIn, nHashType_outmask, sigversion, KeyVersion::ANYPREVOUT, txdata));
+
+            // should fail when no output sighash is set, if any input sighash is set
+            if (nHashType_outmask == 0x0) {
+                uint256 tmp;
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata));
+            }
+
+            // otherwise any output sighash flags should succeed with any input sighash flags
+            else {
+                uint256 shts_acp, shts_apo, shts_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_acp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata));
+                BOOST_CHECK(SignatureHashSchnorr(shts_apo, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata));
+                BOOST_CHECK(SignatureHashSchnorr(shts_apoas, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata));
+                
+                uint256 shts_mut_prevout_acp, shts_mut_prevout_apo, shts_mut_prevout_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_acp, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_apo, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_apoas, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout));
+                
+                uint256 shts_mut_script_acp, shts_mut_script_apo, shts_mut_script_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_acp, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_apo, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_apoas, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script));
+                
+                uint256 shts_mut_sequence_acp, shts_mut_sequence_apo, shts_mut_sequence_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_acp, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_apo, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_apoas, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence));
+
+                uint256 shts_mut_spent_value_acp, shts_mut_spent_value_apo, shts_mut_spent_value_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_acp, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_apo, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_apoas, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value));
+
+                // both transactions must be signed with the SIGHASH_ANYPREVOUT input flag to create identical sighashes if previous input or output information changes
+                BOOST_CHECK(shts != shts_mut_prevout_apo);
+                BOOST_CHECK(shts != shts_mut_script_apo);
+                BOOST_CHECK(shts != shts_mut_sequence_apo);
+                BOOST_CHECK(shts != shts_mut_spent_value_apo);
+                BOOST_CHECK(shts_acp != shts_mut_prevout_apo);
+                BOOST_CHECK(shts_acp != shts_mut_script_apo);
+                BOOST_CHECK(shts_acp != shts_mut_sequence_apo);
+                BOOST_CHECK(shts_acp != shts_mut_spent_value_apo);
+
+                // only when prevout hashes differ does SIGHASH_ANYPREVOUT create identical sighashes 
+                BOOST_CHECK(shts_apo == shts_mut_prevout_apo);
+                BOOST_CHECK(shts_apo != shts_mut_script_apo);
+                if (tx.vin[nIn].nSequence != tx_mut_sequence.vin[nIn].nSequence) {
+                    BOOST_CHECK(shts_apo != shts_mut_sequence_apo);
+                }
+                BOOST_CHECK(shts_apo != shts_mut_spent_value_apo);
+                BOOST_CHECK(shts_apo != shts_mut_sequence_apo);
+
+                // both transactions must be signed with the SIGHASH_ANYPREVOUTANYSCRIPT input flag to create identical sighashes
+                BOOST_CHECK(shts != shts_mut_prevout_apoas);
+                BOOST_CHECK(shts != shts_mut_script_apoas);
+                BOOST_CHECK(shts != shts_mut_sequence_apoas);
+                BOOST_CHECK(shts != shts_mut_spent_value_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_prevout_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_script_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_sequence_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_spent_value_apoas);
+
+                // only when the prevout hashes or input scripts are different does SIGHASH_ANYPREVOUTANYSCRIPT create identical sighashes 
+                BOOST_CHECK(shts_apoas == shts_mut_prevout_apoas);
+                BOOST_CHECK(shts_apoas == shts_mut_script_apoas);
+                if (tx.vin[nIn].nSequence != tx_mut_sequence.vin[nIn].nSequence) {
+                    BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
+                }
+                BOOST_CHECK(shts_apoas != shts_mut_spent_value_apoas);
+                BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
+            }
+        }
+
+        #if defined(PRINT_SIGHASH_JSON)
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << tx;
+
+        std::cout << "\t[\"" ;
+        std::cout << HexStr(ss.begin(), ss.end()) << "\", \"";
+        std::cout << HexStr(scriptCode) << "\", ";
+        std::cout << nIn << ", ";
+        std::cout << nHashType << ", \"";
+        std::cout << sho.GetHex() << "\"]";
+        if (i+1 != nRandomTests) {
+          std::cout << ",";
+        }
+        std::cout << "\n";
+        #endif
+    }
     #if defined(PRINT_SIGHASH_JSON)
     std::cout << "]\n";
     #endif


### PR DESCRIPTION
Unit tests for anyprevout sighashes for both legacy and taproot transactions.

Coverage includes changes to the prevout and sequence of the input transaction and the script and value of spent transactions. 

Test that legacy transactions ignore the anyprevout and anyprevoutanyscript sighash flags.

Test that taproot key version transactions fail for input sighash flags anyonecanpay, anyprevout and anyprevoutanyscript.

Test that tapscript key version transactions using the anyprevout sighash that differ only by their prevout give the same digest hash.

Test that tapscript transactions using the anyprevoutanyscript sighash that differ only by their prevout and/or spent transaction script give the same digest hash.

Test that tapscript transactions which differ in their input transaction sequence or spent transaction value always give different digest hashes.