### PR TITLE
update test framework to match apo implementation in interpreter.h/cpp

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -76,7 +76,8 @@ static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VE
                                                              SCRIPT_VERIFY_TAPROOT |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION |
                                                              SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS |
-                                                             SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE;
+                                                             SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE |
+                                                             SCRIPT_VERIFY_ANYPREVOUT;
 
 /** For convenience, standard but not mandatory verify flags. */
 static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -371,6 +371,7 @@ static bool EvalChecksigPreTapscript(const valtype& vchSig, const valtype& vchPu
 static bool EvalChecksigTapscript(const valtype& sig, const valtype& pubkey, ScriptExecutionData& execdata, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror, bool& success)
 {
     assert(sigversion == SigVersion::TAPSCRIPT);
+    assert(execdata.m_internal_key); // caller must provide the internal key
 
     /*
      *  The following validation sequence is consensus critical. Please note how --

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1586,7 +1586,6 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
         ss << cache.m_spent_outputs[in_pos];
         ss << tx_to.vin[in_pos].nSequence;
     } else if (input_type == SIGHASH_ANYPREVOUTANYSCRIPT) {
-        ss << cache.m_spent_outputs[in_pos].nValue;
         ss << tx_to.vin[in_pos].nSequence;
     } else {
         ss << in_pos;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1896,12 +1896,13 @@ uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint25
     return k;
 }
 
-static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const uint256& tapleaf_hash)
+static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, uint256& tapleaf_hash, std::optional<XOnlyPubKey>* internal_key)
 {
     assert(control.size() >= TAPROOT_CONTROL_BASE_SIZE);
     assert(program.size() >= uint256::size());
     //! The internal pubkey (x-only, so no Y coordinate parity).
     const XOnlyPubKey p{uint256(std::vector<unsigned char>(control.begin() + 1, control.begin() + TAPROOT_CONTROL_BASE_SIZE))};
+    if (internal_key) *internal_key = p;
     //! The output pubkey (taken from the scriptPubKey).
     const XOnlyPubKey q{uint256(program)};
     // Compute the Merkle root from the leaf and the provided path.
@@ -1968,7 +1969,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
                 return set_error(serror, SCRIPT_ERR_TAPROOT_WRONG_CONTROL_SIZE);
             }
             execdata.m_tapleaf_hash = ComputeTapleafHash(control[0] & TAPROOT_LEAF_MASK, exec_script);
-            if (!VerifyTaprootCommitment(control, program, execdata.m_tapleaf_hash)) {
+            if (!VerifyTaprootCommitment(control, program, execdata.m_tapleaf_hash, &execdata.m_internal_key)) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
             }
             execdata.m_tapleaf_hash_init = true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1563,7 +1563,7 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
     // Transaction level data
     ss << tx_to.nVersion;
     ss << tx_to.nLockTime;
-    if (input_type != SIGHASH_ANYONECANPAY) {
+    if (input_type != SIGHASH_ANYONECANPAY && input_type != SIGHASH_ANYPREVOUT && input_type != SIGHASH_ANYPREVOUTANYSCRIPT) {
         ss << cache.m_prevouts_single_hash;
         ss << cache.m_spent_amounts_single_hash;
         ss << cache.m_spent_scripts_single_hash;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1513,7 +1513,7 @@ static bool HandleMissingData(MissingDataBehavior mdb)
 }
 
 template<typename T>
-bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb)
+bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb)
 {
     uint8_t ext_flag;
     assert(keyversion == KeyVersion::TAPROOT || keyversion == KeyVersion::ANYPREVOUT);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -391,7 +391,7 @@ static bool EvalChecksigTapscript(const valtype& sig, const valtype& pubkey, Scr
     if (pubkey.size() == 0) {
         return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
     } else if (pubkey.size() == 32) {
-        if (success && !checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror)) {
+        if (success && !checker.CheckSchnorrSignature(sig, {KeyVersion::TAPROOT, XOnlyPubKey(pubkey)}, sigversion, execdata, serror)) {
             return false; // serror is set
         }
     } else {
@@ -1500,21 +1500,17 @@ static bool HandleMissingData(MissingDataBehavior mdb)
 }
 
 template<typename T>
-bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb)
+bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb)
 {
-    uint8_t ext_flag, key_version;
+    uint8_t ext_flag;
+    assert(keyversion == KeyVersion::TAPROOT);
     switch (sigversion) {
     case SigVersion::TAPROOT:
         ext_flag = 0;
-        // key_version is not used and left uninitialized.
+        // keyversion is not used.
         break;
     case SigVersion::TAPSCRIPT:
         ext_flag = 1;
-        // key_version must be 0 for now, representing the current version of
-        // 32-byte public keys in the tapscript signature opcode execution.
-        // An upgradable public key version (with a size not 32-byte) may
-        // request a different key_version with a new sigversion.
-        key_version = 0;
         break;
     default:
         assert(false);
@@ -1577,7 +1573,7 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
     if (sigversion == SigVersion::TAPSCRIPT) {
         assert(execdata.m_tapleaf_hash_init);
         ss << execdata.m_tapleaf_hash;
-        ss << key_version;
+        ss << uint8_t(keyversion);
         assert(execdata.m_codeseparator_pos_init);
         ss << execdata.m_codeseparator_pos;
     }
@@ -1692,18 +1688,14 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
 }
 
 template <class T>
-bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey_in, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror) const
+bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& verpubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror) const
 {
     assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
-    // Schnorr signatures have 32-byte public keys. The caller is responsible for enforcing this.
-    assert(pubkey_in.size() == 32);
     // Note that in Tapscript evaluation, empty signatures are treated specially (invalid signature that does not
     // abort script execution). This is implemented in EvalChecksigTapscript, which won't invoke
     // CheckSchnorrSignature in that case. In other contexts, they are invalid like every other signature with
     // size different from 64 or 65.
     if (sig.size() != 64 && sig.size() != 65) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_SIZE);
-
-    XOnlyPubKey pubkey{pubkey_in};
 
     uint8_t hashtype = SIGHASH_DEFAULT;
     if (sig.size() == 65) {
@@ -1712,10 +1704,10 @@ bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(Span<const uns
     }
     uint256 sighash;
     if (!this->txdata) return HandleMissingData(m_mdb);
-    if (!SignatureHashSchnorr(sighash, execdata, *txTo, nIn, hashtype, sigversion, *this->txdata, m_mdb)) {
+    if (!SignatureHashSchnorr(sighash, execdata, *txTo, nIn, hashtype, sigversion, verpubkey.version, *this->txdata, m_mdb)) {
         return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
     }
-    if (!VerifySchnorrSignature(sig, pubkey, sighash)) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG);
+    if (!VerifySchnorrSignature(sig, verpubkey.pubkey, sighash)) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG);
     return true;
 }
 
@@ -1928,7 +1920,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
         execdata.m_annex_init = true;
         if (stack.size() == 1) {
             // Key path spending (stack size is 1 after removing optional annex)
-            if (!checker.CheckSchnorrSignature(stack.front(), program, SigVersion::TAPROOT, execdata, serror)) {
+            if (!checker.CheckSchnorrSignature(stack.front(), {KeyVersion::TAPROOT, XOnlyPubKey(program)}, SigVersion::TAPROOT, execdata, serror)) {
                 return false; // serror is set
             }
             return set_success(serror);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -388,11 +388,23 @@ static bool EvalChecksigTapscript(const valtype& sig, const valtype& pubkey, Scr
             return set_error(serror, SCRIPT_ERR_TAPSCRIPT_VALIDATION_WEIGHT);
         }
     }
+
     if (pubkey.size() == 0) {
         return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
     } else if (pubkey.size() == 32) {
         if (success && !checker.CheckSchnorrSignature(sig, {KeyVersion::TAPROOT, XOnlyPubKey(pubkey)}, sigversion, execdata, serror)) {
             return false; // serror is set
+        }
+    } else if ((flags & SCRIPT_VERIFY_ANYPREVOUT) != 0 && (pubkey.size() == 1 || pubkey.size() == 33) && pubkey[0] == 0x01) {
+        if (pubkey.size() == 1) {
+            assert(execdata.m_internal_key);
+            if (success && !checker.CheckSchnorrSignature(sig, {KeyVersion::ANYPREVOUT, *execdata.m_internal_key}, sigversion, execdata, serror)) {
+                return false; // serror is set
+            }
+        } else { // pubkey_in.size() == 33
+            if (success && !checker.CheckSchnorrSignature(sig, {KeyVersion::ANYPREVOUT, XOnlyPubKey(MakeSpan(pubkey).subspan(1))}, sigversion, execdata, serror)) {
+                return false; // serror is set
+            }
         }
     } else {
         /*
@@ -1503,7 +1515,8 @@ template<typename T>
 bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb)
 {
     uint8_t ext_flag;
-    assert(keyversion == KeyVersion::TAPROOT);
+    assert(keyversion == KeyVersion::TAPROOT || keyversion == KeyVersion::ANYPREVOUT);
+    assert(keyversion == KeyVersion::ANYPREVOUT ? sigversion == SigVersion::TAPSCRIPT : true);
     switch (sigversion) {
     case SigVersion::TAPROOT:
         ext_flag = 0;
@@ -1529,7 +1542,21 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
     // Hash type
     const uint8_t output_type = (hash_type == SIGHASH_DEFAULT) ? SIGHASH_ALL : (hash_type & SIGHASH_OUTPUT_MASK); // Default (no sighash byte) is equivalent to SIGHASH_ALL
     const uint8_t input_type = hash_type & SIGHASH_INPUT_MASK;
-    if (!(hash_type <= 0x03 || (hash_type >= 0x81 && hash_type <= 0x83))) return false;
+
+    switch(hash_type) {
+        case 0: case 1: case 2: case 3:
+        case 0x81: case 0x82: case 0x83:
+            break;
+        case 0x41: case 0x42: case 0x43:
+        case 0xc1: case 0xc2: case 0xc3:
+            if (keyversion == KeyVersion::ANYPREVOUT) {
+                break;
+            } else {
+                return false;
+            }
+        default:
+            return false;
+    }
     ss << hash_type;
 
     // Transaction level data
@@ -1554,6 +1581,12 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
         ss << tx_to.vin[in_pos].prevout;
         ss << cache.m_spent_outputs[in_pos];
         ss << tx_to.vin[in_pos].nSequence;
+    } else if (input_type == SIGHASH_ANYPREVOUT) {
+        ss << cache.m_spent_outputs[in_pos];
+        ss << tx_to.vin[in_pos].nSequence;
+    } else if (input_type == SIGHASH_ANYPREVOUTANYSCRIPT) {
+        ss << cache.m_spent_outputs[in_pos].nValue;
+        ss << tx_to.vin[in_pos].nSequence;
     } else {
         ss << in_pos;
     }
@@ -1572,7 +1605,9 @@ bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata
     // Additional data for BIP 342 signatures
     if (sigversion == SigVersion::TAPSCRIPT) {
         assert(execdata.m_tapleaf_hash_init);
-        ss << execdata.m_tapleaf_hash;
+        if (input_type != SIGHASH_ANYPREVOUTANYSCRIPT) {
+            ss << execdata.m_tapleaf_hash;
+        }
         ss << uint8_t(keyversion);
         assert(execdata.m_codeseparator_pos_init);
         ss << execdata.m_codeseparator_pos;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -12,6 +12,7 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 
+#include <optional>
 #include <vector>
 #include <stdint.h>
 
@@ -27,10 +28,12 @@ enum
     SIGHASH_NONE = 2,
     SIGHASH_SINGLE = 3,
     SIGHASH_ANYONECANPAY = 0x80,
+    SIGHASH_ANYPREVOUT = 0x40,
+    SIGHASH_ANYPREVOUTANYSCRIPT = 0xc0,
 
     SIGHASH_DEFAULT = 0, //!< Taproot only; implied when sighash byte is missing, and equivalent to SIGHASH_ALL
     SIGHASH_OUTPUT_MASK = 3,
-    SIGHASH_INPUT_MASK = 0x80,
+    SIGHASH_INPUT_MASK = 0xc0,
 };
 
 /** Script verification flags.
@@ -139,6 +142,9 @@ enum
 
     // Making unknown public key versions (in BIP 342 scripts) non-standard
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE = (1U << 20),
+
+    // Validating ANYPREVOUT public keys
+    SCRIPT_VERIFY_ANYPREVOUT = (1U << 21),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);
@@ -184,6 +190,7 @@ enum class SigVersion
 enum class KeyVersion
 {
     TAPROOT = 0,     //!< 32 byte public key
+    ANYPREVOUT = 1,  //!< 1 or 33 byte public key, first byte is 0x01
 };
 
 struct VersionedXOnlyPubKey
@@ -215,6 +222,9 @@ struct ScriptExecutionData
     bool m_validation_weight_left_init = false;
     //! How much validation weight is left (decremented for every successful non-empty signature check).
     int64_t m_validation_weight_left;
+
+    /** The taproot internal key. */
+    std::optional<XOnlyPubKey> m_internal_key = std::nullopt;
 };
 
 /** Signature hash sizes */

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -10,16 +10,15 @@
 #include <script/script_error.h>
 #include <span.h>
 #include <primitives/transaction.h>
+#include <pubkey.h>
 
 #include <vector>
 #include <stdint.h>
 
 class CPubKey;
-class XOnlyPubKey;
 class CScript;
 class CTransaction;
 class CTxOut;
-class uint256;
 
 /** Signature hash types/flags */
 enum
@@ -182,6 +181,17 @@ enum class SigVersion
     TAPSCRIPT = 3,   //!< Witness v1 with 32-byte program, not BIP16 P2SH-wrapped, script path spending, leaf version 0xc0; see BIP 342
 };
 
+enum class KeyVersion
+{
+    TAPROOT = 0,     //!< 32 byte public key
+};
+
+struct VersionedXOnlyPubKey
+{
+    KeyVersion version;
+    XOnlyPubKey pubkey;
+};
+
 struct ScriptExecutionData
 {
     //! Whether m_tapleaf_hash is initialized.
@@ -233,7 +243,7 @@ public:
         return false;
     }
 
-    virtual bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const
+    virtual bool CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& verpubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const
     {
         return false;
     }
@@ -261,7 +271,7 @@ enum class MissingDataBehavior
 };
 
 template<typename T>
-bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb);
+bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb);
 
 template <class T>
 class GenericTransactionSignatureChecker : public BaseSignatureChecker
@@ -281,7 +291,7 @@ public:
     GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, MissingDataBehavior mdb) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
     GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn, MissingDataBehavior mdb) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
     bool CheckECDSASignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
-    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override;
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& verpubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
     bool CheckSequence(const CScriptNum& nSequence) const override;
 };
@@ -302,9 +312,9 @@ public:
         return m_checker.CheckECDSASignature(scriptSig, vchPubKey, scriptCode, sigversion);
     }
 
-    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& verpubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
     {
-        return m_checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror);
+        return m_checker.CheckSchnorrSignature(sig, verpubkey, sigversion, execdata, serror);
     }
 
     bool CheckLockTime(const CScriptNum& nLockTime) const override

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -353,4 +353,7 @@ bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode)
 
 int FindAndDelete(CScript& script, const CScript& b);
 
+template <typename T>
+bool SignatureHashSchnorr(uint256& hash_out, const ScriptExecutionData& execdata, const T& tx_to, uint32_t in_pos, uint8_t hash_type, SigVersion sigversion, KeyVersion keyversion, const PrecomputedTransactionData& cache, MissingDataBehavior mdb);
+
 #endif // BITCOIN_SCRIPT_INTERPRETER_H

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -92,7 +92,7 @@ bool MutableTransactionSignatureCreator::CreateSchnorrSig(const SigningProvider&
         execdata.m_tapleaf_hash = *leaf_hash;
     }
     uint256 hash;
-    if (!SignatureHashSchnorr(hash, execdata, *txTo, nIn, nHashType, sigversion, *m_txdata, MissingDataBehavior::FAIL)) return false;
+    if (!SignatureHashSchnorr(hash, execdata, *txTo, nIn, nHashType, sigversion, KeyVersion::TAPROOT, *m_txdata, MissingDataBehavior::FAIL)) return false;
     sig.resize(64);
     if (!key.SignSchnorr(hash, sig, merkle_root, nullptr)) return false;
     if (nHashType) sig.push_back(nHashType);
@@ -553,7 +553,7 @@ class DummySignatureChecker final : public BaseSignatureChecker
 public:
     DummySignatureChecker() {}
     bool CheckECDSASignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override { return true; }
-    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror) const override { return true; }
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& verpubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror) const override { return true; }
 };
 const DummySignatureChecker DUMMY_CHECKER;
 

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -34,7 +34,7 @@ public:
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, const VersionedXOnlyPubKey& pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -562,7 +562,7 @@ BOOST_AUTO_TEST_CASE(sighash_anyprevout_taproot)
                 if (tx.vin[nIn].nSequence != tx_mut_sequence.vin[nIn].nSequence) {
                     BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
                 }
-                BOOST_CHECK(shts_apoas != shts_mut_spent_value_apoas);
+                BOOST_CHECK(shts_apoas == shts_mut_spent_value_apoas);
                 BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
             }
         }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -132,6 +132,26 @@ void static MutateInputs(CMutableTransaction &tx, const bool inPrevout, const bo
     }
 }
 
+static std::vector<CTxOut> MutateSpentOutputs(const size_t inNumOutputs, const bool inInputScripts, const bool inValue) {
+    FastRandomContext context(InsecureRand256());
+
+    // default to nValue of 0 and witness script with address of all zeros
+    std::vector<CTxOut> spent_outputs(inNumOutputs, CTxOut(0, CScript() << OP_1 << std::vector<unsigned char>(WITNESS_V1_TAPROOT_SIZE, 0)));
+
+    for (std::size_t in = 0; in < spent_outputs.size(); in++) {
+
+        if (inInputScripts) {
+            spent_outputs[in].scriptPubKey = CScript() << OP_1 << context.randbytes(WITNESS_V1_TAPROOT_SIZE);
+        }
+        
+        if (inValue) {
+            // random, but not default nValue of 0  
+            spent_outputs[in].nValue = InsecureRandRange(99999999)+1;
+        }
+    }
+    return spent_outputs;
+}
+
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
@@ -375,6 +395,194 @@ BOOST_AUTO_TEST_CASE(sighash_anyprevout_legacy)
         BOOST_CHECK(shv0_apoas != shv0_mut_sequence_apoas);
     }
 
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "]\n";
+    #endif
+}
+
+// Goal: check that SignatureHashSchnorr generates the proper hash when inputs are maleated with SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+BOOST_AUTO_TEST_CASE(sighash_anyprevout_taproot)
+{
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "[\n";
+    std::cout << "\t[\"raw_transaction, script, input_index, hashType, signature_hash (result)\"],\n";
+    int nRandomTests = 500;
+    #else
+    int nRandomTests = 50000;
+    #endif
+
+    for (int i=0; i<nRandomTests; i++) {
+
+        // Test random sighash, excluding sighash input flags
+        int nHashType = InsecureRand32() & ~SIGHASH_INPUT_MASK;
+
+        CMutableTransaction tx;
+        RandomTransaction(tx, (nHashType & SIGHASH_OUTPUT_MASK) == SIGHASH_SINGLE);
+        std::for_each(tx.vin.begin(), tx.vin.end(), [](CTxIn& vin){ vin.scriptWitness.stack.push_back({OP_TRUE}); });
+        PrecomputedTransactionData txdata(tx);
+        txdata.Init(tx, MutateSpentOutputs(tx.vin.size(), false, false));
+
+        // test random transaction input
+        int nIn = InsecureRandRange(tx.vin.size());
+
+        // mutate the previous output transaction
+        CMutableTransaction tx_mut_prevout(tx);
+        MutateInputs(tx_mut_prevout, true, false);
+        PrecomputedTransactionData txdata_mut_prevout(tx_mut_prevout);
+        txdata_mut_prevout.Init(tx_mut_prevout, MutateSpentOutputs(tx_mut_prevout.vin.size(), false, false));
+
+        // mutate the previous input script
+        CMutableTransaction tx_mut_script(tx);
+        PrecomputedTransactionData txdata_mut_script(tx_mut_script);
+        txdata_mut_script.Init(tx_mut_script, MutateSpentOutputs(tx_mut_script.vin.size(), true, false));
+
+        // mutate the input sequence
+        CMutableTransaction tx_mut_sequence(tx);  
+        MutateInputs(tx_mut_sequence, false, true); 
+        PrecomputedTransactionData txdata_mut_sequence(tx_mut_sequence);
+        txdata_mut_sequence.Init(tx_mut_sequence, MutateSpentOutputs(tx_mut_sequence.vin.size(), false, false));
+
+        // mutate only the output values of the spent output
+        CMutableTransaction tx_mut_spent_value(tx);
+        PrecomputedTransactionData txdata_mut_spent_value(tx_mut_spent_value);
+        txdata_mut_spent_value.Init(tx_mut_spent_value, MutateSpentOutputs(tx_mut_spent_value.vin.size(), false, true));
+        
+        // only check signature version of v1/TAPSCRIPT (0x3) because EvalChecksig will not allow execution of v1/TAPROOT (0x2) transactions
+        SigVersion sigversion = SigVersion::TAPSCRIPT;
+
+        ScriptExecutionData execdata;
+        execdata.m_annex_init = true;
+        execdata.m_annex_present = InsecureRandBool();
+        execdata.m_annex_hash = InsecureRand256();
+        execdata.m_tapleaf_hash_init = true;
+        execdata.m_tapleaf_hash = InsecureRand256();
+        execdata.m_codeseparator_pos_init = true;
+        execdata.m_codeseparator_pos = InsecureRand32();
+        
+        int nHashType_outmask = nHashType & SIGHASH_OUTPUT_MASK;
+        int nHashType_inoutmask = nHashType & (SIGHASH_INPUT_MASK | SIGHASH_OUTPUT_MASK);
+
+        // any sighash that sets undefined input or output flags should fail
+        if (nHashType_inoutmask != nHashType_outmask && nHashType_inoutmask != nHashType) {
+            uint256 tmp;
+            BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+            BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+        }
+
+        // check transactions using the TAPROOT key version reject ANYPREVOUT
+        {
+            // should fail all sighash input flags if no output flag is set
+            uint256 tmp;
+            if (nHashType_outmask == 0x0) {
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+            }
+            // otherwise all other output sighash flags should fail when any input sighash flags are set except SIGHASH_ANYONECANPAY
+            else {
+                BOOST_CHECK(SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::TAPROOT, txdata, MissingDataBehavior::ASSERT_FAIL));
+            }
+        }
+
+        // check transactions using the ANYPREVOUT key version
+        {
+            // compute base sighash without any input sighash flags
+            uint256 shts;
+            BOOST_CHECK(SignatureHashSchnorr(shts, execdata, tx, nIn, nHashType_outmask, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+
+            // should fail when no output sighash is set, if any input sighash is set
+            if (nHashType_outmask == 0x0) {
+                uint256 tmp;
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(false == SignatureHashSchnorr(tmp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+            }
+
+            // otherwise any output sighash flags should succeed with any input sighash flags
+            else {
+                uint256 shts_acp, shts_apo, shts_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_acp, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_apo, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_apoas, execdata, tx, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata, MissingDataBehavior::ASSERT_FAIL));
+                
+                uint256 shts_mut_prevout_acp, shts_mut_prevout_apo, shts_mut_prevout_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_acp, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_apo, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_prevout_apoas, execdata, tx_mut_prevout, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_prevout, MissingDataBehavior::ASSERT_FAIL));
+                
+                uint256 shts_mut_script_acp, shts_mut_script_apo, shts_mut_script_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_acp, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_apo, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_script_apoas, execdata, tx_mut_script, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_script, MissingDataBehavior::ASSERT_FAIL));
+                
+                uint256 shts_mut_sequence_acp, shts_mut_sequence_apo, shts_mut_sequence_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_acp, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_apo, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_sequence_apoas, execdata, tx_mut_sequence, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_sequence, MissingDataBehavior::ASSERT_FAIL));
+
+                uint256 shts_mut_spent_value_acp, shts_mut_spent_value_apo, shts_mut_spent_value_apoas;
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_acp, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYONECANPAY, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_apo, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYPREVOUT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value, MissingDataBehavior::ASSERT_FAIL));
+                BOOST_CHECK(SignatureHashSchnorr(shts_mut_spent_value_apoas, execdata, tx_mut_spent_value, nIn, nHashType_outmask | SIGHASH_ANYPREVOUTANYSCRIPT, sigversion, KeyVersion::ANYPREVOUT, txdata_mut_spent_value, MissingDataBehavior::ASSERT_FAIL));
+
+                // both transactions must be signed with the SIGHASH_ANYPREVOUT input flag to create identical sighashes if previous input or output information changes
+                BOOST_CHECK(shts != shts_mut_prevout_apo);
+                BOOST_CHECK(shts != shts_mut_script_apo);
+                BOOST_CHECK(shts != shts_mut_sequence_apo);
+                BOOST_CHECK(shts != shts_mut_spent_value_apo);
+                BOOST_CHECK(shts_acp != shts_mut_prevout_apo);
+                BOOST_CHECK(shts_acp != shts_mut_script_apo);
+                BOOST_CHECK(shts_acp != shts_mut_sequence_apo);
+                BOOST_CHECK(shts_acp != shts_mut_spent_value_apo);
+
+                // only when prevout hashes differ does SIGHASH_ANYPREVOUT create identical sighashes 
+                BOOST_CHECK(shts_apo == shts_mut_prevout_apo);
+                BOOST_CHECK(shts_apo != shts_mut_script_apo);
+                if (tx.vin[nIn].nSequence != tx_mut_sequence.vin[nIn].nSequence) {
+                    BOOST_CHECK(shts_apo != shts_mut_sequence_apo);
+                }
+                BOOST_CHECK(shts_apo != shts_mut_spent_value_apo);
+                BOOST_CHECK(shts_apo != shts_mut_sequence_apo);
+
+                // both transactions must be signed with the SIGHASH_ANYPREVOUTANYSCRIPT input flag to create identical sighashes
+                BOOST_CHECK(shts != shts_mut_prevout_apoas);
+                BOOST_CHECK(shts != shts_mut_script_apoas);
+                BOOST_CHECK(shts != shts_mut_sequence_apoas);
+                BOOST_CHECK(shts != shts_mut_spent_value_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_prevout_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_script_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_sequence_apoas);
+                BOOST_CHECK(shts_acp != shts_mut_spent_value_apoas);
+
+                // only when the prevout hashes or input scripts are different does SIGHASH_ANYPREVOUTANYSCRIPT create identical sighashes 
+                BOOST_CHECK(shts_apoas == shts_mut_prevout_apoas);
+                BOOST_CHECK(shts_apoas == shts_mut_script_apoas);
+                if (tx.vin[nIn].nSequence != tx_mut_sequence.vin[nIn].nSequence) {
+                    BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
+                }
+                BOOST_CHECK(shts_apoas != shts_mut_spent_value_apoas);
+                BOOST_CHECK(shts_apoas != shts_mut_sequence_apoas);
+            }
+        }
+
+        #if defined(PRINT_SIGHASH_JSON)
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << tx;
+
+        std::cout << "\t[\"" ;
+        std::cout << HexStr(ss.begin(), ss.end()) << "\", \"";
+        std::cout << HexStr(scriptCode) << "\", ";
+        std::cout << nIn << ", ";
+        std::cout << nHashType << ", \"";
+        std::cout << sho.GetHex() << "\"]";
+        if (i+1 != nRandomTests) {
+          std::cout << ",";
+        }
+        std::cout << "\n";
+        #endif
+    }
     #if defined(PRINT_SIGHASH_JSON)
     std::cout << "]\n";
     #endif

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -114,6 +114,24 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
+void static MutateInputs(CMutableTransaction &tx, const bool inPrevout, const bool inInputSequence) {
+
+    // mutate previous input
+    for (std::size_t in = 0; in < tx.vin.size(); in++) {
+        CTxIn &txin = tx.vin[in];
+
+        if (inPrevout) {
+            txin.prevout.hash = InsecureRand256();
+            txin.prevout.n = InsecureRandBits(2);
+        }
+
+        // mutate input sequences
+        if (inInputSequence) {
+            txin.nSequence = InsecureRand32();
+        }
+    }
+}
+
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
@@ -205,4 +223,161 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
     }
 }
+
+// Goal: check that SignatureHashOld and SignatureHash ignore sighash flags SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+BOOST_AUTO_TEST_CASE(sighash_anyprevout_legacy)
+{
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "[\n";
+    std::cout << "\t[\"raw_transaction, script, input_index, hashType, signature_hash (result)\"],\n";
+    int nRandomTests = 500;
+    #else
+    int nRandomTests = 50000;
+    #endif
+
+    for (int i=0; i<nRandomTests; i++) {
+
+        // random sighashs, with and without ANYPREVOUT*
+        int nHashType = InsecureRand32() & ~SIGHASH_INPUT_MASK;
+        int nHashTypeApo = nHashType | SIGHASH_ANYPREVOUT;
+        int nHashTypeApoas = nHashType | SIGHASH_ANYPREVOUTANYSCRIPT;
+
+        CMutableTransaction tx;
+        RandomTransaction(tx, (nHashType & SIGHASH_OUTPUT_MASK) == SIGHASH_SINGLE);
+        CScript scriptCode, mut_scriptCode;
+        RandomScript(scriptCode);
+        RandomScript(mut_scriptCode);
+
+        // remove code separators from old scripts because they are not serialized
+        CScript old_scriptCode(scriptCode), old_mut_scriptCode(mut_scriptCode);
+        FindAndDelete(old_scriptCode, CScript(OP_CODESEPARATOR));
+        FindAndDelete(old_mut_scriptCode, CScript(OP_CODESEPARATOR));
+        
+        int nIn = InsecureRandRange(tx.vin.size());
+
+        CMutableTransaction tx_mut_prevout(tx);      
+        MutateInputs(tx_mut_prevout, true, false); 
+
+        CMutableTransaction tx_mut_sequence(tx);      
+        MutateInputs(tx_mut_sequence, false, true); 
+
+        // test OLD signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 sho = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashType);
+        uint256 sho_apo = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashTypeApo);
+        uint256 sho_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx), nIn, nHashTypeApoas);
+
+        // mutate the previous output transaction
+        uint256 sho_mut_prevout = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashType);
+        uint256 sho_mut_prevout_apo = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashTypeApo);
+        uint256 sho_mut_prevout_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_prevout), nIn, nHashTypeApoas);
+
+        // mutate the previous input script
+        uint256 sho_mut_script = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashType);
+        uint256 sho_mut_script_apo = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashTypeApo);
+        uint256 sho_mut_script_apoas = SignatureHashOld(old_mut_scriptCode, CTransaction(tx), nIn, nHashTypeApoas);
+
+        // mutate the input sequence
+        uint256 sho_mut_sequence = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashType);
+        uint256 sho_mut_sequence_apo = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashTypeApo);
+        uint256 sho_mut_sequence_apoas = SignatureHashOld(old_scriptCode, CTransaction(tx_mut_sequence), nIn, nHashTypeApoas);
+
+        // test BASE signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 shb = SignatureHash(old_scriptCode, tx, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_apo = SignatureHash(old_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_apoas = SignatureHash(old_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+        
+        // mutate the previous output transaction
+        uint256 shb_mut_prevout = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_prevout_apo = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_prevout_apoas = SignatureHash(old_scriptCode, tx_mut_prevout, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // mutate the previous input script
+        uint256 shb_mut_script = SignatureHash(old_mut_scriptCode, tx, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_script_apo = SignatureHash(old_mut_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_script_apoas = SignatureHash(old_mut_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // mutate the input sequence
+        uint256 shb_mut_sequence = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shb_mut_sequence_apo = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shb_mut_sequence_apoas = SignatureHash(old_scriptCode, tx_mut_sequence, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        // test v0 signature hash ignores SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+        uint256 shv0 = SignatureHash(scriptCode, tx, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_apo = SignatureHash(scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_apoas = SignatureHash(scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the previous output transaction
+        uint256 shv0_mut_prevout = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_prevout_apo = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_prevout_apoas = SignatureHash(scriptCode, tx_mut_prevout, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the previous input script
+        uint256 shv0_mut_script = SignatureHash(mut_scriptCode, tx, nIn, nHashType, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_script_apo = SignatureHash(mut_scriptCode, tx, nIn, nHashTypeApo, 0, SigVersion::WITNESS_V0);
+        uint256 shv0_mut_script_apoas = SignatureHash(mut_scriptCode, tx, nIn, nHashTypeApoas, 0, SigVersion::WITNESS_V0);
+
+        // mutate the input sequence
+        uint256 shv0_mut_sequence = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashType, 0, SigVersion::BASE);
+        uint256 shv0_mut_sequence_apo = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashTypeApo, 0, SigVersion::BASE);
+        uint256 shv0_mut_sequence_apoas = SignatureHash(scriptCode, tx_mut_sequence, nIn, nHashTypeApoas, 0, SigVersion::BASE);
+
+        #if defined(PRINT_SIGHASH_JSON)
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << tx;
+
+        std::cout << "\t[\"" ;
+        std::cout << HexStr(ss.begin(), ss.end()) << "\", \"";
+        std::cout << HexStr(scriptCode) << "\", ";
+        std::cout << nIn << ", ";
+        std::cout << nHashType << ", \"";
+        std::cout << sho.GetHex() << "\"]";
+        if (i+1 != nRandomTests) {
+          std::cout << ",";
+        }
+        std::cout << "\n";
+        #endif
+
+        // check that legacy, base and v0/SEGWIT transactions ignore SIGHASH_ANYPREVOUT and SIGHASH_ANYPREVOUTANYSCRIPT
+
+        // check maleated previous input transaction creates different digests
+        BOOST_CHECK(sho != sho_mut_prevout);
+        BOOST_CHECK(sho_apo != sho_mut_prevout_apo);
+        BOOST_CHECK(sho_apoas != sho_mut_prevout_apoas);
+        BOOST_CHECK(shb != shb_mut_prevout);
+        BOOST_CHECK(shb_apo != shb_mut_prevout_apo);
+        BOOST_CHECK(shb_apoas != shb_mut_prevout_apoas);
+        BOOST_CHECK(shv0 != shv0_mut_prevout);
+        BOOST_CHECK(shv0_apo != shv0_mut_prevout_apo);
+        BOOST_CHECK(shv0_apoas != shv0_mut_prevout_apoas);
+
+        // check maleated input script creates different digests
+        if (old_scriptCode != old_mut_scriptCode) {
+            BOOST_CHECK(sho != sho_mut_script);
+            BOOST_CHECK(sho_apo != sho_mut_script_apo);
+            BOOST_CHECK(sho_apoas != sho_mut_script_apoas);
+            BOOST_CHECK(shb != shb_mut_script);
+            BOOST_CHECK(shb_apo != shb_mut_script_apo);
+            BOOST_CHECK(shb_apoas != shb_mut_script_apoas);
+            BOOST_CHECK(shv0 != shv0_mut_script);
+            BOOST_CHECK(shv0_apo != shv0_mut_script_apo);
+            BOOST_CHECK(shv0_apoas != shv0_mut_script_apoas);
+        }
+
+        // check maleated sequence creates different digests
+        BOOST_CHECK(sho != sho_mut_sequence);
+        BOOST_CHECK(sho_apo != sho_mut_sequence_apo);
+        BOOST_CHECK(sho_apoas != sho_mut_sequence_apoas);
+        BOOST_CHECK(shb != shb_mut_sequence);
+        BOOST_CHECK(shb_apo != shb_mut_sequence_apo);
+        BOOST_CHECK(shb_apoas != shb_mut_sequence_apoas);
+        BOOST_CHECK(shv0 != shv0_mut_sequence);
+        BOOST_CHECK(shv0_apo != shv0_mut_sequence_apo);
+        BOOST_CHECK(shv0_apoas != shv0_mut_sequence_apoas);
+    }
+
+    #if defined(PRINT_SIGHASH_JSON)
+    std::cout << "]\n";
+    #endif
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -41,6 +41,8 @@ typedef std::vector<unsigned char> valtype;
 // In script_tests.cpp
 UniValue read_json(const std::string& jsondata);
 
+#define SCRIPT_VERIFY_NAME(x) {std::string(#x), (unsigned int)SCRIPT_VERIFY_##x}
+
 static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
     {std::string("STRICTENC"), (unsigned int)SCRIPT_VERIFY_STRICTENC},
@@ -63,6 +65,7 @@ static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("DISCOURAGE_UPGRADABLE_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE},
     {std::string("DISCOURAGE_OP_SUCCESS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS},
     {std::string("DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
+    SCRIPT_VERIFY_NAME(ANYPREVOUT),
 };
 
 unsigned int ParseScriptFlags(std::string strFlags)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1700,6 +1700,7 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
     // Start enforcing Taproot using versionbits logic.
     if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_TAPROOT, versionbitscache) == ThresholdState::ACTIVE) {
         flags |= SCRIPT_VERIFY_TAPROOT;
+        flags |= SCRIPT_VERIFY_ANYPREVOUT;
     }
 
     // Start enforcing BIP147 NULLDUMMY (activated simultaneously with segwit)

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -863,11 +863,11 @@ def spenders_taproot_active():
         # 15) OP_CHECKSIGADD with empty key that needs invalid signature
         ("t15", CScript([pubs[1], OP_CHECKSIGVERIFY, OP_0, OP_0, OP_CHECKSIGADD, OP_NOT])),
         # 16) OP_CHECKSIG with unknown pubkey type
-        ("t16", CScript([OP_1, OP_CHECKSIG])),
+        ("t16", CScript([OP_2, OP_CHECKSIG])),
         # 17) OP_CHECKSIGADD with unknown pubkey type
-        ("t17", CScript([OP_0, OP_1, OP_CHECKSIGADD])),
+        ("t17", CScript([OP_0, OP_2, OP_CHECKSIGADD])),
         # 18) OP_CHECKSIGVERIFY with unknown pubkey type
-        ("t18", CScript([OP_1, OP_CHECKSIGVERIFY, OP_1])),
+        ("t18", CScript([OP_2, OP_CHECKSIGVERIFY, OP_1])),
         # 19) script longer than 10000 bytes and over 201 non-push opcodes
         ("t19", CScript([OP_0, OP_0, OP_2DROP] * 10001 + [pubs[1], OP_CHECKSIG])),
         # 20) OP_CHECKSIGVERIFY with empty key
@@ -927,11 +927,11 @@ def spenders_taproot_active():
     add_spender(spenders, "tapscript/minimalnotif", leaf="t6", **common, inputs=[getter("sign"), b'\x01'], failure={"inputs": [getter("sign"), b'\x03']}, **ERR_MINIMALIF)
     add_spender(spenders, "tapscript/minimalif", leaf="t5", **common, inputs=[getter("sign"), b'\x01'], failure={"inputs": [getter("sign"), b'\x0001']}, **ERR_MINIMALIF)
     add_spender(spenders, "tapscript/minimalnotif", leaf="t6", **common, inputs=[getter("sign"), b'\x01'], failure={"inputs": [getter("sign"), b'\x0100']}, **ERR_MINIMALIF)
-    # Test that 1-byte public keys (which are unknown) are acceptable but nonstandard with unrelated signatures, but 0-byte public keys are not valid.
+    # Test that 1-byte OP_2 public keys (which are unknown) are acceptable but nonstandard with unrelated signatures, but 0-byte public keys are not valid.
     add_spender(spenders, "tapscript/unkpk/checksig", leaf="t16", standard=False, **common, **SINGLE_SIG, failure={"leaf": "t7"}, **ERR_UNKNOWN_PUBKEY)
     add_spender(spenders, "tapscript/unkpk/checksigadd", leaf="t17", standard=False, **common, **SINGLE_SIG, failure={"leaf": "t10"}, **ERR_UNKNOWN_PUBKEY)
     add_spender(spenders, "tapscript/unkpk/checksigverify", leaf="t18", standard=False, **common, **SINGLE_SIG, failure={"leaf": "t8"}, **ERR_UNKNOWN_PUBKEY)
-    # Test that 33-byte public keys (which are unknown) are acceptable but nonstandard with valid signatures, but normal pubkeys are not valid in that case.
+    # Test that 33-byte public keys beginning with 0x02 or 0x03 (which are unknown) are acceptable but nonstandard with valid signatures, but normal pubkeys are not valid in that case.
     add_spender(spenders, "tapscript/oldpk/checksig", leaf="t30", standard=False, **common, **SINGLE_SIG, sighash=bitflipper(default_sighash), failure={"leaf": "t1"}, **ERR_SIG_SCHNORR)
     add_spender(spenders, "tapscript/oldpk/checksigadd", leaf="t31", standard=False, **common, **SINGLE_SIG, sighash=bitflipper(default_sighash), failure={"leaf": "t2"}, **ERR_SIG_SCHNORR)
     add_spender(spenders, "tapscript/oldpk/checksigverify", leaf="t32", standard=False, **common, **SINGLE_SIG, sighash=bitflipper(default_sighash), failure={"leaf": "t28"}, **ERR_SIG_SCHNORR)

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1327,6 +1327,7 @@ class TaprootTest(BitcoinTestFramework):
 
         left = done
         while left:
+            self.log.info("- left %i" % left)
             # Construct CTransaction with random nVersion, nLocktime
             tx = CTransaction()
             tx.nVersion = random.choice([1, 2, random.randint(-0x80000000, 0x7fffffff)])

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -749,7 +749,7 @@ class TestFrameworkScript(unittest.TestCase):
         for value in values:
             self.assertEqual(CScriptNum.decode(CScriptNum.encode(CScriptNum(value))), value)
 
-def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT):
+def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT, key_ver = KEY_VERSION_TAPROOT):
     assert (len(txTo.vin) == len(spent_utxos))
     assert key_ver == KEY_VERSION_TAPROOT or key_ver == KEY_VERSION_ANYPREVOUT
     if key_ver == KEY_VERSION_TAPROOT:

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -780,12 +780,12 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
     ss += bytes([spend_type])
     if in_type == SIGHASH_ANYONECANPAY:
         ss += txTo.vin[input_index].prevout.serialize()
-        ss += ser_string(spk)
         ss += struct.pack("<q", spent_utxos[input_index].nValue)
+        ss += ser_string(spk)
         ss += struct.pack("<I", txTo.vin[input_index].nSequence)
     elif in_type == SIGHASH_ANYPREVOUT:
-        ss += ser_string(spk)
         ss += struct.pack("<q", spent_utxos[input_index].nValue)
+        ss += ser_string(spk)
         ss += struct.pack("<I", txTo.vin[input_index].nSequence)
     elif in_type == SIGHASH_ANYPREVOUTANYSCRIPT:
         ss += struct.pack("<q", spent_utxos[input_index].nValue)

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -752,11 +752,8 @@ class TestFrameworkScript(unittest.TestCase):
 def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT, key_ver = KEY_VERSION_TAPROOT):
     assert (len(txTo.vin) == len(spent_utxos))
     assert key_ver == KEY_VERSION_TAPROOT or key_ver == KEY_VERSION_ANYPREVOUT
-    if key_ver == KEY_VERSION_TAPROOT:
-        assert((hash_type >= 0 and hash_type <= 3) or (hash_type >= 0x81 and hash_type <= 0x83))
     if key_ver == KEY_VERSION_ANYPREVOUT:
-        assert scriptpath
-        assert hash_type in [0,1,2,3,0x41,0x42,0x43,0x81,0x82,0x83,0xc1,0xc2,0xc3]
+        assert False # not tested yet
     assert (input_index < len(txTo.vin))
     out_type = SIGHASH_ALL if hash_type == 0 else hash_type & 3
     in_type = hash_type & SIGHASH_OUTMASK
@@ -804,7 +801,8 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
             ss += TaggedHash("TapLeaf", bytes([leaf_ver]) + ser_string(script))
         ss += bytes([key_ver])
         ss += struct.pack("<i", codeseparator_pos)
-    assert len(ss) ==  175 - (in_type == SIGHASH_ANYONECANPAY) * 49 - (out_type != SIGHASH_ALL and out_type != SIGHASH_SINGLE) * 32 + (annex is not None) * 32 + scriptpath * 37
+    if in_type not in [SIGHASH_ANYPREVOUT, SIGHASH_ANYPREVOUTANYSCRIPT]:
+        assert len(ss) ==  175 - (in_type == SIGHASH_ANYONECANPAY) * 49 - (out_type != SIGHASH_ALL and out_type != SIGHASH_SINGLE) * 32 + (annex is not None) * 32 + scriptpath * 37
     return TaggedHash("TapSighash", ss)
 
 def taproot_tree_helper(scripts):

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -785,7 +785,6 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
         ss += ser_string(spk)
         ss += struct.pack("<I", txTo.vin[input_index].nSequence)
     elif in_type == SIGHASH_ANYPREVOUTANYSCRIPT:
-        ss += struct.pack("<q", spent_utxos[input_index].nValue)
         ss += struct.pack("<I", txTo.vin[input_index].nSequence) 
     else:
         ss += struct.pack("<I", input_index)

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -607,7 +607,8 @@ SIGHASH_ANYONECANPAY = 0x80
 SIGHASH_ANYPREVOUT = 0x40
 SIGHASH_ANYPREVOUTANYSCRIPT = 0xc0
 
-SIGHASH_OUTMASK = 0xc0
+SIGHASH_INMASK = 0xc0
+SIGHASH_OUTMASK = 0x03
 
 def FindAndDelete(script, sig):
     """Consensus critical, see FindAndDelete() in Satoshi codebase"""
@@ -752,11 +753,10 @@ class TestFrameworkScript(unittest.TestCase):
 def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT, key_ver = KEY_VERSION_TAPROOT):
     assert (len(txTo.vin) == len(spent_utxos))
     assert key_ver == KEY_VERSION_TAPROOT or key_ver == KEY_VERSION_ANYPREVOUT
-    if key_ver == KEY_VERSION_ANYPREVOUT:
-        assert False # not tested yet
+    assert key_ver != KEY_VERSION_ANYPREVOUT or scriptpath
     assert (input_index < len(txTo.vin))
-    out_type = SIGHASH_ALL if hash_type == 0 else hash_type & 3
-    in_type = hash_type & SIGHASH_OUTMASK
+    out_type = SIGHASH_ALL if hash_type == SIGHASH_DEFAULT else hash_type & SIGHASH_OUTMASK
+    in_type = hash_type & SIGHASH_INMASK
     spk = spent_utxos[input_index].scriptPubKey
     ss = bytes([0, hash_type]) # epoch, hash_type
     ss += struct.pack("<i", txTo.nVersion)

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -30,6 +30,9 @@ LOCKTIME_THRESHOLD = 500000000
 ANNEX_TAG = 0x50
 
 LEAF_VERSION_TAPSCRIPT = 0xc0
+KEY_VERSION_TAPROOT = 0x00
+KEY_VERSION_ANYPREVOUT = 0x01
+
 
 def hash160(s):
     return hashlib.new('ripemd160', sha256(s)).digest()
@@ -601,6 +604,10 @@ SIGHASH_ALL = 1
 SIGHASH_NONE = 2
 SIGHASH_SINGLE = 3
 SIGHASH_ANYONECANPAY = 0x80
+SIGHASH_ANYPREVOUT = 0x40
+SIGHASH_ANYPREVOUTANYSCRIPT = 0xc0
+
+SIGHASH_OUTMASK = 0xc0
 
 def FindAndDelete(script, sig):
     """Consensus critical, see FindAndDelete() in Satoshi codebase"""
@@ -744,13 +751,20 @@ class TestFrameworkScript(unittest.TestCase):
 
 def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpath = False, script = CScript(), codeseparator_pos = -1, annex = None, leaf_ver = LEAF_VERSION_TAPSCRIPT):
     assert (len(txTo.vin) == len(spent_utxos))
+    assert key_ver == KEY_VERSION_TAPROOT or key_ver == KEY_VERSION_ANYPREVOUT
+    if key_ver == KEY_VERSION_TAPROOT:
+        assert((hash_type >= 0 and hash_type <= 3) or (hash_type >= 0x81 and hash_type <= 0x83))
+    if key_ver == KEY_VERSION_ANYPREVOUT:
+        assert scriptpath
+        assert hash_type in [0,1,2,3,0x41,0x42,0x43,0x81,0x82,0x83,0xc1,0xc2,0xc3]
     assert (input_index < len(txTo.vin))
     out_type = SIGHASH_ALL if hash_type == 0 else hash_type & 3
-    in_type = hash_type & SIGHASH_ANYONECANPAY
+    in_type = hash_type & SIGHASH_OUTMASK
     spk = spent_utxos[input_index].scriptPubKey
     ss = bytes([0, hash_type]) # epoch, hash_type
     ss += struct.pack("<i", txTo.nVersion)
     ss += struct.pack("<I", txTo.nLockTime)
+
     if in_type != SIGHASH_ANYONECANPAY:
         ss += sha256(b"".join(i.prevout.serialize() for i in txTo.vin))
         ss += sha256(b"".join(struct.pack("<q", u.nValue) for u in spent_utxos))
@@ -766,9 +780,16 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
     ss += bytes([spend_type])
     if in_type == SIGHASH_ANYONECANPAY:
         ss += txTo.vin[input_index].prevout.serialize()
-        ss += struct.pack("<q", spent_utxos[input_index].nValue)
         ss += ser_string(spk)
+        ss += struct.pack("<q", spent_utxos[input_index].nValue)
         ss += struct.pack("<I", txTo.vin[input_index].nSequence)
+    elif in_type == SIGHASH_ANYPREVOUT:
+        ss += ser_string(spk)
+        ss += struct.pack("<q", spent_utxos[input_index].nValue)
+        ss += struct.pack("<I", txTo.vin[input_index].nSequence)
+    elif in_type == SIGHASH_ANYPREVOUTANYSCRIPT:
+        ss += struct.pack("<q", spent_utxos[input_index].nValue)
+        ss += struct.pack("<I", txTo.vin[input_index].nSequence) 
     else:
         ss += struct.pack("<I", input_index)
     if (spend_type & 1):
@@ -779,8 +800,9 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
         else:
             ss += bytes(0 for _ in range(32))
     if (scriptpath):
-        ss += TaggedHash("TapLeaf", bytes([leaf_ver]) + ser_string(script))
-        ss += bytes([0])
+        if in_type != SIGHASH_ANYPREVOUTANYSCRIPT:
+            ss += TaggedHash("TapLeaf", bytes([leaf_ver]) + ser_string(script))
+        ss += bytes([key_ver])
         ss += struct.pack("<i", codeseparator_pos)
     assert len(ss) ==  175 - (in_type == SIGHASH_ANYONECANPAY) * 49 - (out_type != SIGHASH_ALL and out_type != SIGHASH_SINGLE) * 32 + (annex is not None) * 32 + scriptpath * 37
     return TaggedHash("TapSighash", ss)

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -762,7 +762,7 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
     ss += struct.pack("<i", txTo.nVersion)
     ss += struct.pack("<I", txTo.nLockTime)
 
-    if in_type != SIGHASH_ANYONECANPAY:
+    if in_type != SIGHASH_ANYONECANPAY and in_type != SIGHASH_ANYPREVOUT and in_type != SIGHASH_ANYPREVOUTANYSCRIPT:
         ss += sha256(b"".join(i.prevout.serialize() for i in txTo.vin))
         ss += sha256(b"".join(struct.pack("<q", u.nValue) for u in spent_utxos))
         ss += sha256(b"".join(ser_string(u.scriptPubKey) for u in spent_utxos))


### PR DESCRIPTION
Changes to sync with bitcoind anyprevout changes include:
 * sighash masks and logic to match [interpreter.h/cpp](https://github.com/ajtowns/bitcoin/blob/6e263c1ed229a6936def1a15976686a0d0d32f70/src/script/interpreter.h#L35)
 * sync with [do not use cached _single_hash for anyprevout* sighashs](https://github.com/ajtowns/bitcoin/commit/6e263c1ed229a6936def1a15976686a0d0d32f70)
 * sync with [APOAS indifferent to value being spent](https://github.com/ajtowns/bitcoin/commit/d3bb0183f5b0ccdea61665e3a6ab3d4f9217ec7f) 
