### PR TITLE
Move towards compile-time type safety for arg registration

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,6 +136,7 @@ BITCOIN_CORE_H = \
   clientversion.h \
   coins.h \
   common/args.h \
+  common/argsregister.h \
   common/bloom.h \
   common/init.h \
   common/run_command.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,6 +21,15 @@
 #include <stdexcept>
 #include <vector>
 
+void SetupChainParamsOptions(ArgsManager& argsman)
+{
+    argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
+}
+
+
 void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& options)
 {
     if (args.IsArgSet("-signetseednode")) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -25,7 +25,7 @@ void SetupChainParamsOptions(ArgsManager& argsman)
 {
     argsman.AddArg("-fastprune", "Use smaller block files and lower minimum prune height for testing purposes", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -23,6 +23,7 @@
 
 void SetupChainParamsOptions(ArgsManager& argsman)
 {
+    argsman.AddArg("-fastprune", "Use smaller block files and lower minimum prune height for testing purposes", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -13,6 +13,11 @@
 class ArgsManager;
 
 /**
+ * Setup configuration options
+ */
+void SetupChainParamsOptions(ArgsManager& argsman);
+
+/**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
  */
 std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, const ChainType chain);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -16,12 +16,8 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -489,6 +489,28 @@ std::optional<int64_t> ArgsManager::GetIntArg(const std::string& strArg) const
     return SettingToInt(value);
 }
 
+template<>
+std::optional<std::string> ArgsManager::Get<std::string>(const std::string& arg) const
+{
+    return GetArg(arg);
+}
+
+template<>
+std::optional<bool> ArgsManager::Get<bool>(const std::string& arg) const
+{
+    return GetBoolArg(arg);
+}
+
+template<>
+std::optional<std::vector<std::string>> ArgsManager::Get<std::vector<std::string>>(const std::string& arg) const
+{
+    std::optional<std::vector<std::string>> result{GetArgs(arg)};
+    if (result.has_value() && result.value().empty()) {
+        result.reset();
+    }
+    return result;
+}
+
 std::optional<int64_t> SettingToInt(const common::SettingsValue& value)
 {
     if (value.isNull()) return std::nullopt;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -261,6 +261,15 @@ protected:
     bool IsArgNegated(const std::string& strArg) const;
 
     /**
+     * Return typed argument if present
+     *
+     * @param arg Argument to get (e.g. "-foo")
+     * @return command-line argument or nullopt
+     */
+    template<typename T>
+    std::optional<T> Get(const std::string& arg) const;
+
+    /**
      * Return string argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")
@@ -342,6 +351,17 @@ protected:
      * Add argument
      */
     void AddArg(const std::string& name, const std::string& help, unsigned int flags, const OptionsCategory& cat);
+
+    /**
+     * Add typed argument
+     */
+    template<typename T>
+    void AddTypedArg(const std::string& name, const std::string& help, unsigned int flags, const OptionsCategory& cat)
+    {
+        // able to asssociate type information with argument directly in future,
+        // eg specialise AddTypedArg<std::vector<std::string>> to call AddArg(name, help, flags|ALLOW_LIST, cat).
+        AddArg(name, help, flags, cat);
+    }
 
     /**
      * Add subcommand

--- a/src/common/argsregister.h
+++ b/src/common/argsregister.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_ARGSREGISTER_H
+#define BITCOIN_COMMON_ARGSREGISTER_H
+
+#include <common/args.h>
+
+#include <type_traits>
+
+/** Typesafe args registration.  */
+
+/** Example usage:
+
+constexpr bool DEFAULT_FOO_A{true};
+
+struct FooOpts {
+    bool a{DEFAULT_FOO_A};
+    std::optional<std::string> b;
+    std::vector<std::string> c;
+    Custom d;
+};
+
+class FooRegister
+{
+public:
+    using T = CChainParams::SigNetOptions;
+
+    static inline void GetD(Custom& d, const std::string& arg_d);
+
+    template<typename C, typename Op>
+    static inline void Register(Op& op)
+    {
+        return C::Do(op,
+            C::Defn(&T::a, "-fooa", "",
+                    "Description of option A",
+                    ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION,
+                    OptionsCategory::DEBUG_TEST),
+            C::Defn(&T::b, "-foob", "=bar",
+                    "Description of option B",
+                    ArgsManager::ALLOW_ANY,
+                    OptionsCategory::DEBUG_TEST),
+            C::Defn(&T::c, "-foob", "=bar",
+                    "Description of option B",
+                    ArgsManager::ALLOW_ANY,
+                    OptionsCategory::DEBUG_TEST),
+            C::Defn(&T::d, "-foob", "=bar", GetD,
+                    "Description of option B",
+                    ArgsManager::ALLOW_ANY,
+                    OptionsCategory::DEBUG_TEST)
+            );
+    }
+};
+
+void SetupFooOptions(ArgsManager& argsman)
+{
+    ArgsRegister<FooArgsRegister>::Register(argsman);
+}
+
+void ReadFooArgs(const ArgsManager& args, FooOpts& options)
+{
+    ArgsRegister<FooArgsRegister>::Update(args, options);
+}
+
+**/
+
+template<typename REG>
+class ArgsRegister
+{
+public:
+    using STRUCT = typename REG::T;
+
+    static inline void Register(ArgsManager& args)
+    {
+        auto l = [&](const auto& sd) {
+            using AT = typename std::remove_reference_t<decltype(sd)>::ArgType;
+            args.AddTypedArg<AT>(sd.name+sd.params, sd.desc, sd.flags, sd.cat);
+        };
+        (REG::template Register<_Do>)(l);
+    }
+
+    static inline void Update(const ArgsManager& args, STRUCT& options)
+    {
+        auto l = [&](const auto& sd) {
+            using AT = typename std::remove_reference_t<decltype(sd)>::ArgType;
+            auto arg = args.Get<AT>(sd.name);
+            if (arg.has_value()) {
+                sd.cvt(options.*(sd.field), arg.value());
+            }
+        };
+        (REG::template Register<_Do>)(l);
+    }
+
+private:
+    template<typename FT, typename AT=FT>
+    struct ArgDefn
+    {
+        using FieldType = FT;
+        using ArgType = AT;
+
+        void (&cvt)(FieldType&, const ArgType&);
+        FieldType STRUCT::* field;
+        std::string name;
+        std::string params; // "=blah" or ""
+        std::string desc;
+        unsigned int flags;
+        OptionsCategory cat;
+    };
+
+    class _Do
+    {
+    private:
+        template<typename Op>
+        static inline void Do(Op& op) { }
+
+        template<typename T>
+        static inline void set_directly(T& dst, const T& src) { dst = src; }
+
+        template<typename T>
+        static inline void set_optional(std::optional<T>& dst, const T& src) { dst = src; }
+
+    public:
+        template<typename T, typename... Ts>
+        static inline ArgDefn<std::optional<T>, T> Defn(std::optional<T> STRUCT::* field, const std::string& name, const std::string& params, const std::string& desc, Ts... ts)
+        {
+            return { set_optional<T>, field, name, params, desc, ts... };
+        }
+
+        template<typename T, typename... Ts>
+        static inline ArgDefn<T> Defn(T STRUCT::* field, const std::string& name, const std::string& params, const std::string& desc, Ts... ts)
+        {
+            return { set_directly<T>, field, name, params, desc, ts... };
+        }
+
+        template<typename FT, typename AT, typename... Ts>
+        static inline ArgDefn<FT,AT> Defn(FT STRUCT::* field, const std::string& name, const std::string& params, void(&cvt)(FT&,const AT&), const std::string& desc, Ts... ts)
+        {
+            return { cvt, field, name, params, desc, ts... };
+        }
+
+        template<typename Op, typename FT, typename AT, typename... Ts>
+        static inline void Do(Op& op, const ArgDefn<FT, AT>& sd, Ts... ts)
+        {
+            op(sd);
+            Do(op, ts...);
+        }
+    };
+};
+
+#endif // BITCOIN_COMMON_ARGSREGISTER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -436,7 +436,6 @@ void SetupServerArgs(ArgsManager& argsman)
 #endif
     argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-fastprune", "Use smaller block files and lower minimum prune height for testing purposes", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
 #if HAVE_SYSTEM
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -584,6 +584,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-uacomment=<cmt>", "Append comment to the user agent string", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 
     SetupChainParamsBaseOptions(argsman);
+    SetupChainParamsOptions(argsman);
 
     argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !testnetChainParams->RequireStandard()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kvB) used to define cost of relay, used for mempool limiting and replacement policy. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);


### PR DESCRIPTION
Introduce `ArgsRegister` for defining arg parsing in a single location.

Idea is that we have two types, the `FieldType` (eg `RegTestOptions::version_bits_parameters` has type `std::unordered_map<Consensus::DeploymentPos, VersionBitsParameter>`) and the `ArgType` for which we specialise `std::optional<ArgType> ArgsManager::Get<ArgType>(std::string& argname` in `common/args.cpp`. Then, any argument that we register via `ArgsRegister` either has `FieldType = ArgType` or `FieldType = std::optional<ArgType>` or has an explicit conversion function.

In future we can then also specialise `ArgsManager::AddTypedArg<FieldType>` to give earlier errors (eg by automatically adding `ALLOW_LIST` etc).