### PR TITLE
202406 early logs

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -820,16 +820,6 @@ void InitParameterInteraction(ArgsManager& args)
  */
 void InitLogging(const ArgsManager& args)
 {
-    for (int i = 0; i < 5000; ++i) {
-        LogInfo("Log spam, #%d\n", i);
-    }
-    LogInfo("Here's an info message...");
-    LogInfo("...continued\n");
-    LogWarning("Warning\n");
-    LogError("Error\n");
-    LogDebug(BCLog::NET, "net debug\n");
-    std::this_thread::sleep_for(3s);
-
     init::SetLoggingOptions(args);
     init::LogPackageVersion();
 }
@@ -1148,13 +1138,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         // Detailed error printed inside CreatePidFile().
         return false;
     }
-
     if (!init::StartLogging(args)) {
         // Detailed error printed inside StartLogging().
         return false;
     }
-
-    LogInfo("STARTED LOGGING\n");
 
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -820,6 +820,16 @@ void InitParameterInteraction(ArgsManager& args)
  */
 void InitLogging(const ArgsManager& args)
 {
+    for (int i = 0; i < 5000; ++i) {
+        LogInfo("Log spam, #%d\n", i);
+    }
+    LogInfo("Here's an info message...");
+    LogInfo("...continued\n");
+    LogWarning("Warning\n");
+    LogError("Error\n");
+    LogDebug(BCLog::NET, "net debug\n");
+    std::this_thread::sleep_for(3s);
+
     init::SetLoggingOptions(args);
     init::LogPackageVersion();
 }
@@ -1138,10 +1148,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         // Detailed error printed inside CreatePidFile().
         return false;
     }
+
     if (!init::StartLogging(args)) {
         // Detailed error printed inside StartLogging().
         return false;
     }
+
+    LogInfo("STARTED LOGGING\n");
 
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -72,15 +72,16 @@ bool BCLog::Logger::StartLogging()
     // dump buffered messages from before we opened the log
     m_buffering = false;
     while (!m_msgs_before_open.empty()) {
-        const std::string& s = m_msgs_before_open.front();
+        const auto& buflog = m_msgs_before_open.front();
+        std::string s{buflog.str};
+        FormatLogStrInPlace(s, buflog.category, buflog.level, buflog.source_file, buflog.source_line, buflog.logging_function, buflog.threadname, buflog.now, buflog.mocktime);
+        m_msgs_before_open.pop_front();
 
         if (m_print_to_file) FileWriteStr(s, m_fileout);
         if (m_print_to_console) fwrite(s.data(), 1, s.size(), stdout);
         for (const auto& cb : m_print_callbacks) {
             cb(s);
         }
-
-        m_msgs_before_open.pop_front();
     }
     if (m_print_to_console) fflush(stdout);
 
@@ -276,28 +277,23 @@ std::string BCLog::Logger::LogLevelsString() const
     return Join(std::vector<BCLog::Level>{levels.begin(), levels.end()}, ", ", [](BCLog::Level level) { return LogLevelToStr(level); });
 }
 
-std::string BCLog::Logger::LogTimestampStr(const std::string& str)
+std::string BCLog::Logger::LogTimestampStr(SystemClock::time_point now, std::chrono::seconds mocktime) const
 {
     std::string strStamped;
 
     if (!m_log_timestamps)
-        return str;
+        return strStamped;
 
-    if (m_started_new_line) {
-        const auto now{SystemClock::now()};
-        const auto now_seconds{std::chrono::time_point_cast<std::chrono::seconds>(now)};
-        strStamped = FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now_seconds));
-        if (m_log_time_micros && !strStamped.empty()) {
-            strStamped.pop_back();
-            strStamped += strprintf(".%06dZ", Ticks<std::chrono::microseconds>(now - now_seconds));
-        }
-        std::chrono::seconds mocktime = GetMockTime();
-        if (mocktime > 0s) {
-            strStamped += " (mocktime: " + FormatISO8601DateTime(count_seconds(mocktime)) + ")";
-        }
-        strStamped += ' ' + str;
-    } else
-        strStamped = str;
+    const auto now_seconds{std::chrono::time_point_cast<std::chrono::seconds>(now)};
+    strStamped = FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now_seconds));
+    if (m_log_time_micros && !strStamped.empty()) {
+        strStamped.pop_back();
+        strStamped += strprintf(".%06dZ", Ticks<std::chrono::microseconds>(now - now_seconds));
+    }
+    if (mocktime > 0s) {
+        strStamped += " (mocktime: " + FormatISO8601DateTime(count_seconds(mocktime)) + ")";
+    }
+    strStamped += ' ';
 
     return strStamped;
 }
@@ -350,32 +346,51 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
     return s;
 }
 
+void BCLog::Logger::FormatLogStrInPlace(std::string& str, BCLog::LogFlags category, BCLog::Level level, std::string source_file, int source_line, std::string logging_function, std::string threadname, SystemClock::time_point now, std::chrono::seconds mocktime) const
+{
+    str.insert(0, GetLogPrefix(category, level));
+
+    if (m_log_sourcelocations) {
+        str.insert(0, "[" + RemovePrefix(source_file, "./") + ":" + ToString(source_line) + "] [" + logging_function + "] ");
+    }
+
+    if (m_log_threadnames) {
+        str.insert(0, "[" + (threadname.empty() ? "unknown" : threadname) + "] ");
+    }
+
+    str.insert(0, LogTimestampStr(now, mocktime));
+}
+
 void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level)
 {
     StdLockGuard scoped_lock(m_cs);
     std::string str_prefixed = LogEscapeMessage(str);
 
-    if (m_started_new_line) {
-        str_prefixed.insert(0, GetLogPrefix(category, level));
-    }
-
-    if (m_log_sourcelocations && m_started_new_line) {
-        str_prefixed.insert(0, "[" + RemovePrefix(source_file, "./") + ":" + ToString(source_line) + "] [" + logging_function + "] ");
-    }
-
-    if (m_log_threadnames && m_started_new_line) {
-        const auto& threadname = util::ThreadGetInternalName();
-        str_prefixed.insert(0, "[" + (threadname.empty() ? "unknown" : threadname) + "] ");
-    }
-
-    str_prefixed = LogTimestampStr(str_prefixed);
-
+    const bool starts_new_line = m_started_new_line;
     m_started_new_line = !str.empty() && str[str.size()-1] == '\n';
 
     if (m_buffering) {
-        // buffer if we haven't started logging yet
-        m_msgs_before_open.push_back(str_prefixed);
+        if (!starts_new_line && !m_msgs_before_open.empty()) {
+            m_msgs_before_open.back().str += str;
+        } else {
+            BufferedLog buf{
+                .now=SystemClock::now(),
+                .mocktime=GetMockTime(),
+                .str=str_prefixed,
+                .logging_function=logging_function,
+                .source_file=source_file,
+                .threadname=util::ThreadGetInternalName(),
+                .source_line=source_line,
+                .category=category,
+                .level=level,
+            };
+            m_msgs_before_open.push_back(buf);
+        }
         return;
+    }
+
+    if (starts_new_line) {
+        FormatLogStrInPlace(str_prefixed, category, level, source_file, source_line, logging_function, util::ThreadGetInternalName(), SystemClock::now(), GetMockTime());
     }
 
     if (m_print_to_console) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -83,9 +83,7 @@ namespace BCLog {
 
     class Logger
     {
-    private:
-        mutable StdMutex m_cs; // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected
-
+    public:
         struct BufferedLog {
             SystemClock::time_point now;
             std::chrono::seconds mocktime;
@@ -95,9 +93,14 @@ namespace BCLog {
             Level level;
         };
 
+    private:
+        mutable StdMutex m_cs; // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected
+
         FILE* m_fileout GUARDED_BY(m_cs) = nullptr;
         std::list<BufferedLog> m_msgs_before_open GUARDED_BY(m_cs);
         bool m_buffering GUARDED_BY(m_cs) = true; //!< Buffer messages before logging can be started.
+        size_t m_max_buffer_memusage GUARDED_BY(m_cs){1000000}; // buffer up to 1MB of log data prior to StartLogging
+        size_t m_cur_buffer_memusage GUARDED_BY(m_cs){0};
 
         /**
          * m_started_new_line is a state variable that will suppress printing of


### PR DESCRIPTION
* commit 1 adds some early log spam for testing
* commit 2 makes early log buffer the information, so it can be formatted according to options set later
* commit 3 adds a limit so the early buffer doesn't grow too large. 1MB of memory data seems to cover up to ~4300 log lines, if they're short (tracking source location, threadnames, etc add a bunch of extra data even if they end up unused)
* commit 4 reverts commit 1, because runnng the tests with spam and a sleep in init is pretty painful